### PR TITLE
[Fix] 네이버 장소 검색 API ->  카카오 장소 검색 API

### DIFF
--- a/STITCH/STITCH/Application/DIContainer/AppDIContainer.swift
+++ b/STITCH/STITCH/Application/DIContainer/AppDIContainer.swift
@@ -27,13 +27,10 @@ final class AppDIContainer {
         return DefaultURLSessionNetworkService(config: config)
     }()
     
-    lazy var naverOpenAPIService: URLSessionNetworkService = {
+    lazy var kakaoOpenAPIService: URLSessionNetworkService = {
         let config = NetworkConfig(
-            baseURL: URL(string: "https://openapi.naver.com/v1/search/local.json")!,
-            headers: [
-                "X-Naver-Client-Id": APIKey.naverClientID,
-                "X-Naver-Client-Secret": APIKey.naverClientSecret
-            ]
+            baseURL: URL(string: "https://dapi.kakao.com")!,
+            headers: ["Authorization": "KakaoAK \(APIKey.kakaoAPIKey)"]
         )
         return DefaultURLSessionNetworkService(config: config)
     }()
@@ -69,7 +66,7 @@ final class AppDIContainer {
             urlsessionNetworkService: urlsessionNetworkService,
             userDefaultsService: userDefaultsService,
             naverCloudAPIService: naverCloudAPIService,
-            naverOpenAPIService: naverOpenAPIService,
+            searchOpenAPIService: kakaoOpenAPIService,
             appleIDService: appleIDService,
             userUseCase: userUseCase
         )

--- a/STITCH/STITCH/Application/DIContainer/TabBarDIContainer.swift
+++ b/STITCH/STITCH/Application/DIContainer/TabBarDIContainer.swift
@@ -13,7 +13,7 @@ final class TabBarDIContainer: TabBarCoordinatorDependencies {
         let urlsessionNetworkService: URLSessionNetworkService
         let userDefaultsService: UserDefaultsService
         let naverCloudAPIService: URLSessionNetworkService
-        let naverOpenAPIService: URLSessionNetworkService
+        let searchOpenAPIService: URLSessionNetworkService
         let appleIDService: URLSessionNetworkService
         let userUseCase: UserUseCase
     }
@@ -77,7 +77,7 @@ final class TabBarDIContainer: TabBarCoordinatorDependencies {
     // MARK: Location
     
     func searchLocationRepository() -> SearchLocationRepository {
-        return DefaultSearchLocationRepository(naverAPINetworkService: dependencies.naverOpenAPIService)
+        return DefaultSearchLocationRepository(searchAPINetworkService: dependencies.searchOpenAPIService)
     }
     
     // MARK: - Use Cases

--- a/STITCH/STITCH/Common/Constant/APIKey.swift
+++ b/STITCH/STITCH/Common/Constant/APIKey.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 struct ServiceAPIKey: Codable {
+    let kakaoAPIKey: String
     let privateAuthKey: String
     let clientID: String
     let clientSecret: String
@@ -16,28 +17,20 @@ struct ServiceAPIKey: Codable {
 }
 
 struct APIKey {
+    static var kakaoAPIKey: String {
+        guard let serviceInfoURL = Bundle.main.url(forResource: "Service-Info", withExtension: "plist"),
+              let data = try? Data(contentsOf: serviceInfoURL),
+              let apiKey = try? PropertyListDecoder().decode(ServiceAPIKey.self, from: data)
+        else { return "" }
+        return apiKey.kakaoAPIKey
+    }
+    
     static var privateAuthKey: String {
         guard let serviceInfoURL = Bundle.main.url(forResource: "Service-Info", withExtension: "plist"),
               let data = try? Data(contentsOf: serviceInfoURL),
               let apiKey = try? PropertyListDecoder().decode(ServiceAPIKey.self, from: data)
         else { return "" }
         return apiKey.privateAuthKey
-    }
-    
-    static var naverClientID: String {
-        guard let serviceInfoURL = Bundle.main.url(forResource: "Service-Info", withExtension: "plist"),
-              let data = try? Data(contentsOf: serviceInfoURL),
-              let apiKey = try? PropertyListDecoder().decode(ServiceAPIKey.self, from: data)
-        else { return "" }
-        return apiKey.clientID
-    }
-    
-    static var naverClientSecret: String {
-        guard let serviceInfoURL = Bundle.main.url(forResource: "Service-Info", withExtension: "plist"),
-              let data = try? Data(contentsOf: serviceInfoURL),
-              let apiKey = try? PropertyListDecoder().decode(ServiceAPIKey.self, from: data)
-        else { return "" }
-        return apiKey.clientSecret
     }
     
     static var naverCloudClientID: String {

--- a/STITCH/STITCH/Data/Entities/SearchLocationDTO.swift
+++ b/STITCH/STITCH/Data/Entities/SearchLocationDTO.swift
@@ -8,13 +8,24 @@
 import Foundation
 
 struct SearchLocationDTO: Decodable {
-    let items: [SearchLocationItem]?
+    let meta: Meta
+    let documents: [Document]
 }
 
-struct SearchLocationItem: Decodable {
-    let title: String
-    let address: String
-    let roadAddress: String
-    let mapx: String
-    let mapy: String
+struct Meta: Decodable {
+    let same_name: SearchName
+}
+
+struct SearchName: Decodable {
+    let region: [String]
+    let keyword: String
+    let selected_region: String
+}
+
+struct Document: Decodable {
+    let place_name: String
+    let address_name: String
+    let road_address_name: String
+    let x: String // longitude
+    let y: String // latitude
 }

--- a/STITCH/STITCH/Data/Network/APIEndpoints.swift
+++ b/STITCH/STITCH/Data/Network/APIEndpoints.swift
@@ -195,12 +195,11 @@ struct LocationAPIEndpoints {
     
     static func fetchSearchLocations(query: String) -> Endpoint {
         return Endpoint(
-            path: "",
+            path: "/v2/local/search/keyword.json",
             method: .GET,
             queryParameters: [
                 "query": query,
-                "display": 5,
-                "sort": "random"
+                "display": 45
             ]
         )
     }

--- a/STITCH/STITCH/Data/Repository/Location/DefaultSearchLocationRepository.swift
+++ b/STITCH/STITCH/Data/Repository/Location/DefaultSearchLocationRepository.swift
@@ -13,31 +13,31 @@ final class DefaultSearchLocationRepository: SearchLocationRepository {
     
     // MARK: - Properties
     
-    private let naverAPINetworkService: URLSessionNetworkService
+    private let searchAPINetworkService: URLSessionNetworkService
     
     // MARK: - Initializer
     
-    init(naverAPINetworkService: URLSessionNetworkService) {
-        self.naverAPINetworkService = naverAPINetworkService
+    init(searchAPINetworkService: URLSessionNetworkService) {
+        self.searchAPINetworkService = searchAPINetworkService
     }
     
     // MARK: - Methods
     
     func fetchSearchLocations(query: String) -> Observable<[LocationInfo]> {
         let endpoint = LocationAPIEndpoints.fetchSearchLocations(query: query)
-        return naverAPINetworkService.request(with: endpoint)
+        return searchAPINetworkService.request(with: endpoint)
             .map(SearchLocationDTO.self)
-            .compactMap { $0.items }
+            .compactMap { $0.documents }
             .map {
-                return $0.map {
-                    let title = $0.title.replacingOccurrences(of: "<b>", with: "")
-                        .replacingOccurrences(of: "</b>", with: "")
-                    return LocationInfo(
-                        address: "\($0.address), \(title)",
-                        roadAddress: $0.roadAddress,
-                        katechX: $0.mapx,
-                        katechY: $0.mapy
-                    ) }
+                return $0.map { document in
+                    LocationInfo(
+                        address: document.address_name,
+                        placeName: document.place_name,
+                        roadAddress: document.road_address_name,
+                        latitude: document.y,
+                        longitude: document.x
+                    )
+                }
             }
     }
 }

--- a/STITCH/STITCH/Presentation/Common/View/LocationResultCollectionView/LocationResultCollectionView.swift
+++ b/STITCH/STITCH/Presentation/Common/View/LocationResultCollectionView/LocationResultCollectionView.swift
@@ -34,7 +34,7 @@ final class LocationResultCollectionView: BaseCollectionView {
             cell.backgroundConfiguration = backgroundConfig
             
             var content = cell.defaultContentConfiguration()
-            content.text = locationInfo.address
+            content.text = "\(locationInfo.placeName ?? "")"
             content.textProperties.font = .Body1_16 ?? .systemFont(ofSize: 16, weight: .regular)
             content.textProperties.color = .gray02
             cell.contentConfiguration = content

--- a/STITCH/STITCH/Presentation/Model/LocationInfo.swift
+++ b/STITCH/STITCH/Presentation/Model/LocationInfo.swift
@@ -11,6 +11,7 @@ import MapKit
 
 struct LocationInfo: Codable, Hashable {
     var address: String
+    var placeName: String?
     var roadAddress: String?
     var latitude: String?
     var longitude: String?
@@ -19,6 +20,7 @@ struct LocationInfo: Codable, Hashable {
     
     init(
         address: String,
+        placeName: String? = nil,
         roadAddress: String? = nil,
         latitude: String? = nil,
         longitude: String? = nil,
@@ -26,6 +28,7 @@ struct LocationInfo: Codable, Hashable {
         katechY: String? = nil
     ) {
         self.address = address
+        self.placeName = placeName
         self.roadAddress = roadAddress
         self.latitude = latitude
         self.longitude = longitude


### PR DESCRIPTION
- 변경이유 : 네이버 장소 검색은 최대 5개까지 지원, 카카오 장소 검색 API는 default 15개 까지 지원

[네이버검색 > 지역 - Search API](https://developers.naver.com/docs/serviceapi/search/local/local.md#%EC%A7%80%EC%97%AD)

[Kakao Developers - Local Rest API](https://developers.kakao.com/docs/latest/ko/local/dev-guide#search-by-keyword)