### PR TITLE
[Fix] 주소 입력 에러 수정

### DIFF
--- a/STITCH/STITCH/Common/Constant/APIKey.swift
+++ b/STITCH/STITCH/Common/Constant/APIKey.swift
@@ -10,8 +10,6 @@ import Foundation
 struct ServiceAPIKey: Codable {
     let kakaoAPIKey: String
     let privateAuthKey: String
-    let clientID: String
-    let clientSecret: String
     let cloudClientID: String
     let cloudClientSecret: String
 }

--- a/STITCH/STITCH/Data/Repository/Location/DefaultNearAddressRespository.swift
+++ b/STITCH/STITCH/Data/Repository/Location/DefaultNearAddressRespository.swift
@@ -51,12 +51,12 @@ final class DefaultNearAddressRepository: NearAddressRepository {
     func fetchNearAddresses(text: String) -> Observable<[LocationInfo]> {
         let endpoint = LocationAPIEndpoints.fetchGeoCodingAddress(query: text)
         return naverCloudNetworkService.request(with: endpoint)
-            .retry()
+            .retry(1)
             .map(GeoCodingResultDTO.self)
             .compactMap { $0.addresses }
             .map { addresses in
                 let dongAddresses = addresses.filter { !$0.addressElements[2].longName.isEmpty }
-                return dongAddresses.map { LocationInfo(address: $0.jibunAddress) }
+                return dongAddresses.map { LocationInfo(address: $0.jibunAddress, placeName: $0.jibunAddress) }
             }
     }
 }

--- a/STITCH/STITCH/Presentation/TabBar/Coordinator/TabBarCoordinator.swift
+++ b/STITCH/STITCH/Presentation/TabBar/Coordinator/TabBarCoordinator.swift
@@ -168,7 +168,7 @@ extension TabBarCoordinator {
                     } else if let matchCategoryViewController {
                         matchCategoryViewController.didReceive(locationInfo: locationInfo)
                     }
-                    owner.popViewController()
+                    navigationController.popViewController(animated: true)
                 }
             }
             .disposed(by: disposeBag)

--- a/STITCH/STITCH/Presentation/TabBar/Home/Home/HomeViewController.swift
+++ b/STITCH/STITCH/Presentation/TabBar/Home/Home/HomeViewController.swift
@@ -310,11 +310,12 @@ final class HomeViewController: BaseViewController {
    }
     
     func didReceive(locationInfo: LocationInfo) {
-        locationButton.setTitle(locationInfo.address, for: .normal)
         homeViewModel.userUpdate(address: locationInfo.address)
-            .withUnretained(self)
-            .subscribe { owner, user in
+            .asDriver(onErrorJustReturn: User())
+            .drive { [weak self] user in
+                guard let owner = self else { return }
                 guard let address = user.address.components(separatedBy: " ").last else { return }
+                print(address)
                 owner.locationButton.set(text: address, .location)
             }
             .disposed(by: disposeBag)

--- a/STITCH/STITCH/Presentation/TabBar/MatchCategory/MatchCategoryViewController.swift
+++ b/STITCH/STITCH/Presentation/TabBar/MatchCategory/MatchCategoryViewController.swift
@@ -260,10 +260,10 @@ final class MatchCategoryViewController: BaseViewController {
     }
     
     func didReceive(locationInfo: LocationInfo) {
-        locationButton.setTitle(locationInfo.address, for: .normal)
         matchCategoryViewModel.userUpdate(address: locationInfo.address)
-            .withUnretained(self)
-            .subscribe { owner, user in
+            .asDriver(onErrorJustReturn: User())
+            .drive { [weak self] user in
+                guard let owner = self else { return }
                 guard let address = user.address.components(separatedBy: " ").last else { return }
                 owner.locationButton.set(text: address, .location)
             }


### PR DESCRIPTION
에러 원인
- naver open api 클라이언트 키를 plist에서 제외했는데 APIKey Struct 제외를 안했더니 디코딩 오류

주소 입력 후 홈화면, 카테고리 화면으로 돌아와서 주소 입력되는 부분 수정
- subscribe -> drive